### PR TITLE
Build snap

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.github/workflows/promote-snap.yaml
+++ b/.github/workflows/promote-snap.yaml
@@ -1,0 +1,45 @@
+name: Promote Snap
+
+on:
+  workflow_dispatch:
+    inputs:
+      promotion:
+        type: choice
+        description: Channel to promote from
+        options:
+          - edge -> beta
+          - beta -> candidate
+          - candidate -> stable
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+
+jobs:
+  promote:
+    name: Promote Snap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: sudo snap install --classic --channel edge snapcraft
+      - name: Set target channel
+        env:
+          PROMOTE_FROM: ${{ github.event.inputs.promotion }}
+        run: |
+          if [ "${PROMOTE_FROM}" == "edge -> beta" ]; then
+            echo "promote-from=edge" >> ${GITHUB_ENV}
+            echo "promote-to=beta" >> ${GITHUB_ENV}
+          elif [ "${PROMOTE_FROM}" == "beta -> candidate" ]; then
+            echo "promote-from=beta" >> ${GITHUB_ENV}
+            echo "promote-to=candidate" >> ${GITHUB_ENV}
+          elif [ "${PROMOTE_FROM}" == "candidate -> stable" ]; then
+            echo "promote-from=candidate" >> ${GITHUB_ENV}
+            echo "promote-to=stable" >> ${GITHUB_ENV}
+          fi
+      - name: Fetch Revision
+        run: |
+          SNAP_RELEASES=$(curl -s -H "Snap-Device-Series: 16" "http://api.snapcraft.io/v2/snaps/info/snmp-notifier?fields=revision")
+          REVISION=$(echo $SNAP_RELEASES | jq '."channel-map"[] | select(.channel.risk=="${{ env.promote-from }}").revision')
+          echo "revision=$REVISION" >> ${GITHUB_ENV}
+      - name: Promote Snap
+        run: |
+          snapcraft release snmp-notifier ${{ env.revision }} ${{ env.promote-to }}

--- a/.github/workflows/release-snap.yaml
+++ b/.github/workflows/release-snap.yaml
@@ -1,0 +1,40 @@
+name: Release Snap
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+  LAUNCHPAD_TOKEN: ${{ secrets.LAUNCHPAD_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v0.1.1
+        with:
+          channel: latest/stable
+
+      - name: Install dependencies
+        run: |
+          sudo snap install --classic --channel edge snapcraft
+          # Setup Launchpad credentials
+          mkdir -p ~/.local/share/snapcraft/provider/launchpad
+          echo -e "$LAUNCHPAD_TOKEN" >> ~/.local/share/snapcraft/provider/launchpad/credentials
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "Github Actions"
+      - name: Build Snap (remote)
+        run: snapcraft remote-build --launchpad-accept-public-upload
+
+      - name: Upload and Publish amd64 Snap
+        run: snapcraft upload --release edge snmp-notifier_*_amd64.snap
+
+      - name: Upload and Publish arm64 Snap
+        run: snapcraft upload --release edge snmp-notifier_*_arm64.snap

--- a/.github/workflows/update-snap.yaml
+++ b/.github/workflows/update-snap.yaml
@@ -1,0 +1,67 @@
+name: Update Snap on new releases of its source
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  schedule:
+    - cron: '0 0,4,8,12,16,20 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-version:
+    name: Detect new releases
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo snap install yq
+
+      - id: latest-release
+        uses: pozetroninc/github-action-get-latest-release@v0.6.0
+        with:
+          repository: maxwo/snmp_notifier
+          excludes: prerelease, draft
+
+      - name: Checkout the Snap source
+        uses: actions/checkout@v3
+        with:
+          path: main
+
+      - id: check
+        name: Check for new releases
+        shell: bash
+        run: |
+          release=$(yq '.parts.snmp-notifier["source-tag"]' $GITHUB_WORKSPACE/main/snap/snapcraft.yaml)
+          if [ "${release}" != "${{steps.latest-release.outputs.release}}" ]; then
+            echo "release=${{steps.latest-release.outputs.release}}" >> $GITHUB_OUTPUT
+            echo "New upstream release ${{steps.latest-release.outputs.release}} found"
+          else
+            echo "No new upstream release found"
+          fi
+
+      - name: Update the application version
+        if: ${{ steps.check.outputs.release != '' }}
+        shell: bash
+        run: |
+          source_tag="${{ steps.check.outputs.release }}" \
+          version=${source_tag#"v"} \
+          yq -i '.version = strenv(version) | .parts.snmp-notifier["source-tag"] = strenv(source_tag)' $GITHUB_WORKSPACE/main/snap/snapcraft.yaml
+
+      - name: Create a PR
+        if: ${{ steps.check.outputs.release != '' }}
+        uses: peter-evans/create-pull-request@v4.2.3
+        with:
+          path: main
+          token: ${{ secrets.OBSERVABILITY_NOCTUA_TOKEN }}
+          commit-message: "chore(deps): bump snmp_notifier version to ${{ steps.check.outputs.release }}"
+          committer: "Github Actions <github-actions@github.com>"
+          author: "Github Actions <github-actions@github.com>"
+          title: "Update to snmp_notifier ${{ steps.check.outputs.release }}"
+          body: Automated update to follow upstream [release](https://github.com/maxwo/snmp_notifier/releases/tag/${{ steps.check.outputs.release }}) of snmp_notifier.
+          branch: "chore/bump-version-to-${{ steps.check.outputs.release }}"
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+#snapcraft specifics
+/parts/
+/stage/
+/prime/
+
+*.snap
+
+.snapcraft
+__pycache__
+*.pyc
+*_source.tar.bz2
+snap/.snapcraft

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,14 @@
+extends: default
+rules:
+  new-line-at-end-of-file:
+    level: error
+  trailing-spaces:
+    level: error
+  document-start:
+    level: warning
+  line-length:
+    level: warning
+  indentation:
+    level: error
+  empty-lines:
+    level: error

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 Maxime Wojtczak
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,4 @@
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -186,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Maxime Wojtczak
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+lint:
+	yamllint snap/snapcraft.yaml
+	shellcheck snap/hooks/*
+	shellcheck snap/local/*
+
+clean:
+	rm -f snmp-notifier*.snap
+	sudo snap remove --purge snmp-notifier
+	snapcraft clean
+
+rebuild: clean
+	snapcraft
+
+install:
+	sudo snap install --dangerous *.snap

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+<h1 align="center">
+  <br />
+  SNMP Notifier
+</h1>
+
+<p align="center"><a href="https://github.com/sed-i/snmp-notifier-snap/actions/workflows/release-snap.yaml"><img src="https://github.com/sed-i/snmp-notifier-snap/actions/workflows/release-snap.yaml/badge.svg"></a></p>
+
+<p align="center"><b>This is the snap for SNMP Notifier</b>, <i>“SNMP Notifier receives alerts from the Prometheus' Alertmanager and routes them as SNMP traps.”</i>. It works on Ubuntu, Fedora, Debian, and other major Linux
+distributions.</p>
+
+<p align="center"><a href="https://snapcraft.io/snmp-notifier"><img src="https://snapcraft.io/snmp-notifier/badge.svg" alt="snmp-notifier badge"/><a/></p>
+
+<p align="center">Published for <img src="https://raw.githubusercontent.com/anythingcodes/slack-emoji-for-techies/gh-pages/emoji/tux.png" align="top" width="24" /> with 💝 by Snapcrafters</p>
+
+## Install
+### From source
+```bash
+snapcraft
+sudo snap install --dangerous *.snap
+```
+
+Once installed, it runs as a service in the background.
+
+<!-- Uncomment and modify this when your snap is available on the store
+### From the snap store
+```
+sudo snap install snmp-notifier
+```
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-white.svg)](https://snapcraft.io/snmp-notifier)
+-->
+
+([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
+
+## Configure
+
+Snap config options match snmp_notifier cli arguments. Currently, supporting:
+
+| `snmp_notifier` cli arg            | snap config option               |
+|------------------------------------|----------------------------------|
+| `--web.listen-address`             | `web.listen-address`             |
+| `--snmp.destination`               | `snmp.destination`               |
+| `--alert.severities`               | `alert.severities`               |
+| `--snmp.trap-description-template` | `snmp.trap-description-template` |
+
+You can configure the snap like so:
+
+```bash
+snap set snmp-notifier \
+  web.listen-address=127.0.0.1:9464 \
+  snmp.destination=127.0.0.1:162 \
+  alert.severities="critical,warning,info"
+```

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,11 @@
+#!/bin/sh -eu
+
+. "${SNAP}/bin/common-utilities"
+
+web_listen_address
+snmp_destination
+snmp_trap_description_template
+alert_severities
+
+snapctl restart snmp-notifier
+

--- a/snap/hooks/default-configure
+++ b/snap/hooks/default-configure
@@ -1,0 +1,18 @@
+#!/bin/sh -eu
+
+# The default-configure hook is needed because the app is started before the config hook runs, which results in the
+# following errors in the log:
+# 
+# snmp-notifier.snmp-notifier[112252]: snmp_notifier: error: path '' does not exist, try --help
+# systemd[1]: snap.snmp-notifier.snmp-notifier.service: Main process exited, code=exited, status=1/FAILURE
+# systemd[1]: snap.snmp-notifier.snmp-notifier.service: Failed with result 'exit-code'.
+# systemd[1]: snap.snmp-notifier.snmp-notifier.service: Scheduled restart job, restart counter is at 1.
+# 
+# With this hook in place, the wrapper is able to start the app with defaults in place.
+
+. "${SNAP}/bin/common-utilities"
+
+web_listen_address
+snmp_destination
+snmp_trap_description_template
+alert_severities

--- a/snap/local/common-utilities
+++ b/snap/local/common-utilities
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+web_listen_address() {
+    value="$(snapctl get web.listen-address)"
+    if [ -z "$value" ]; then
+            value="127.0.0.1:9464"
+            snapctl set web.listen-address="$value"
+    fi
+    echo "$value"
+}
+
+snmp_destination() {
+    value="$(snapctl get snmp.destination)"
+    if [ -z "$value" ]; then
+            value="127.0.0.1:162"
+            snapctl set snmp.destination="$value"
+    fi
+    echo "$value"
+}
+
+snmp_trap_description_template() {
+    value="$(snapctl get snmp.trap-description-template)"
+    if [ -z "$value" ]; then
+            value="${SNAP_DATA}/description-template.tpl"
+            snapctl set snmp.trap-description-template="$value"
+    fi
+    echo "$value"
+}
+
+alert_severities() {
+    value="$(snapctl get alert.severities)"
+    if [ -z "$value" ]; then
+            value="critical,warning,info"
+            snapctl set alert.severities="$value"
+    fi
+    echo "$value"
+}

--- a/snap/local/snmp_notifier.wrapper
+++ b/snap/local/snmp_notifier.wrapper
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+test -e "${SNAP_DATA}/description-template.tpl" || cp "${SNAP}/etc/snmp_notifier/description-template.tpl" "${SNAP_DATA}/description-template.tpl"
+
+exec "${SNAP}/bin/snmp_notifier" \
+  --web.listen-address="$(snapctl get web.listen-address)" \
+  --snmp.destination="$(snapctl get snmp.destination)" \
+  --snmp.trap-description-template="$(snapctl get snmp.trap-description-template)" \
+  --alert.severities="$(snapctl get alert.severities)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,63 @@
+name: snmp-notifier
+version: '1.5.0'
+summary: A webhook to relay Prometheus alerts as SNMP traps.
+license: Apache-2.0
+contact: simon.aronsson@canonical.com
+issues: https://github.com/canonical/snmp-notifier-snap/issues
+source-code: https://github.com/canonical/snmp-notifier-snap
+website: https://github.com/maxwo/snmp_notifier
+description: snmp_notifier receives alerts from the Prometheus' Alertmanager and routes them as SNMP traps.
+base: core22
+grade: stable
+confinement: strict
+
+apps:
+  # Snapcraft does not permit underscores in app names, so we go with a dash instead.
+  # https://bugs.launchpad.net/snapcraft/+bug/1616507
+  snmp-notifier:
+    command: bin/snmp_notifier.wrapper
+    daemon: simple
+    plugs:
+      - home
+      - network
+      - network-bind
+      - network-observe
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+hooks:
+  configure: {}
+
+parts:
+  snmp-notifier:
+    plugin: go
+    source: https://github.com/maxwo/snmp_notifier
+    source-type: git
+    source-tag: "v1.5.0"
+    build-snaps:
+      # go version should match the project's go.mod
+      - go/1.21/stable
+    override-build: |
+      craftctl default
+      cp -p "${CRAFT_PART_BUILD}/description-template.tpl" "${CRAFT_PART_INSTALL}/"
+    organize:
+      description-template.tpl: etc/snmp_notifier/description-template.tpl
+
+  snap-wrappers:
+    plugin: dump
+    source: ./snap/local
+    organize:
+      snmp_notifier.wrapper: bin/snmp_notifier.wrapper
+      common-utilities: bin/common-utilities
+    prime:
+      - bin/snmp_notifier.wrapper
+      - bin/common-utilities
+
+  hooks:
+    plugin: dump
+    source: ./snap/hooks
+    organize:
+      configure: snap/hooks/configure
+      default-configure: snap/hooks/default-configure


### PR DESCRIPTION
This PR commits the code that was used to build the first edge release of https://snapcraft.io/snmp-notifier.

Doc references:
- https://snapcraft.io/docs/go-applications
- https://snapcraft.io/docs/supported-interfaces
- https://forum.snapcraft.io/t/adding-snap-configuration/15246
- https://forum.snapcraft.io/t/configure-snaps/510
- https://forum.snapcraft.io/t/supported-snap-hooks/3795#heading--the-configure-hook
- https://forum.snapcraft.io/t/using-the-snapctl-tool/15002

Snap references:
- https://github.com/canonical/grafana-agent-snap/blob/main/snap/snapcraft.yaml
- https://git.launchpad.net/prometheus-alertmanager-snap/tree/snap_config_wrapper
- https://github.com/nextcloud-snap/nextcloud-snap/blob/master/src/hooks/bin/configure
- https://github.com/canonical/ubuntu-frame/blob/main/snap/snapcraft.yaml
- https://github.com/sergiusens/matrix-server/blob/master/snap/hooks/configure#L18